### PR TITLE
fix(android): don't resolve too early

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/inappreview/InAppReviewPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/inappreview/InAppReviewPlugin.java
@@ -17,7 +17,5 @@ public class InAppReviewPlugin extends Plugin {
     public void requestReview(PluginCall call) {
         final AppCompatActivity activity = getActivity();
         implementation.requestReview(call, activity);
-
-        call.resolve();
     }
 }


### PR DESCRIPTION
The `InAppReview` class already has some `resolve` and `reject` calls, so don't call resolve here as it makes it resolve before the plugin gets the callbacks